### PR TITLE
Fixes #3

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -111,7 +111,7 @@ DurandalGenerator.prototype.starter = function starter() {
 };
 
 DurandalGenerator.prototype.gruntfile = function gruntfile() {
-    this.template('_gruntfile.js', 'Gruntfile.js');
+    this.copy('_gruntfile.js', 'Gruntfile.js');
 };
 
 DurandalGenerator.prototype.package = function _package() {


### PR DESCRIPTION
Instead of using the template method (which calls _.template without the
fancy <%% overrides), call the copy method which will run the file through
the custom yeoman templating engine.
